### PR TITLE
Add: use button instead of checkbox

### DIFF
--- a/extension/picker/picker.css
+++ b/extension/picker/picker.css
@@ -16,21 +16,18 @@
   margin: 0.5em;
 	padding: 0.5em;
 	text-align: center;
+	background: transparent;
 }
 .image-checkbox.checked {
 	background: skyblue;
 }
-.image-checkbox.disable {
+.image-checkbox[disabled] {
 	opacity: 0.2;
 }
 .image-checkbox img {
 	display: block;
 	max-height: calc(var(--previewMaxHeight, 200) * 1px);
 	margin: 0 auto;
-}
-.image-checkbox input[type=checkbox] {
-  display: block;
-  margin: 0.5em auto 0;
 }
 .image-checkbox-info {
 	display: block;
@@ -97,7 +94,7 @@
 .image-checkbox {
 	counter-increment: images-total images-tab-total;
 }
-.image-checkbox.checked:not(.disable) {
+.image-checkbox.checked:not([disabled]) {
 	counter-increment: images-total images-selected images-tab-total images-tab-selected;
 }
 .save::after {

--- a/extension/picker/picker.css
+++ b/extension/picker/picker.css
@@ -1,3 +1,7 @@
+:root {
+	--main-border: hsl(197, 91%, 63%);
+}
+
 /* container */
 #container {
   padding: 60px 0;
@@ -11,7 +15,7 @@
 	align-items: center;
 }
 .image-checkbox {
-  border: 1px solid skyblue;
+  border: 1px solid var(--main-border);
   float: left;
   margin: 0.5em;
 	padding: 0.5em;
@@ -19,7 +23,7 @@
 	background: transparent;
 }
 .image-checkbox.checked {
-	background: skyblue;
+	background: var(--main-border);
 }
 .image-checkbox[disabled] {
 	opacity: 0.2;
@@ -105,7 +109,7 @@
 	top: -2.5px;
 	left: 1em;
 	background: white;
-	border: 1px solid skyblue;
+	border: 1px solid var(--main-border);
 	padding: 0.1em 0.6em;
 	font-family: monospace;
 	transform: translateY(-50%);
@@ -122,6 +126,6 @@
 .tab-container .image-container {
 	margin: 1.4em 1em;
 	padding: 0.5em;
-	border: 5px dashed skyblue;
+	border: 5px dashed var(--main-border);
 	position: relative;
 }

--- a/extension/picker/picker.js
+++ b/extension/picker/picker.js
@@ -168,9 +168,10 @@ function createImageCheckbox(url) {
 		ctrl.toggleCheck();
 	};
 	button.className = "image-checkbox checked";
+	button.title = url;
 		
 	img.src = url;
-	img.title = url;
+	img.draggable = false; // for chrome
 	button.appendChild(img);
 	
 	load();
@@ -199,10 +200,10 @@ function createImageCheckbox(url) {
 					img.parentNode.insertBefore(info, img.nextSibling);
 				} else {
 					if (img.naturalWidth) {
-						img.title += ` (${img.naturalWidth} x ${img.naturalHeight})`;
+						button.title += ` (${img.naturalWidth} x ${img.naturalHeight})`;
 					}
 				}
-				img.title += ` [${formatFileSize(img.fileSize)}]`;
+				button.title += ` [${formatFileSize(img.fileSize)}]`;
 				
 				// default width for svg
 				if (!img.naturalHeight) {

--- a/extension/picker/picker.js
+++ b/extension/picker/picker.js
@@ -159,44 +159,68 @@ function initFilter(container, images) {
 }
 
 function createImageCheckbox(url) {
-	var label = document.createElement("label"),
-		img = new Image,
-		input = document.createElement("input"),
-		enable = true,
-		ctrl;
+	const button = document.createElement("button");
+	const img = new Image;
+	let ctrl;
+	
+	button.type = "button";
+	button.onclick = () => {
+		ctrl.toggleCheck();
+	};
+	button.className = "image-checkbox checked";
 		
 	img.src = url;
 	img.title = url;
+	button.appendChild(img);
 	
-	Promise.all([loadImage(), loadFileSize(), pref.ready()])
-		.then(() => {
-			if (pref.get("displayImageSizeUnderThumbnail")) {
-				const info = document.createElement("span");
-				info.className = "image-checkbox-info";
-				info.textContent = `${img.naturalWidth} x ${img.naturalHeight}`;
-				img.parentNode.insertBefore(info, img.nextSibling);
-			} else {
-				if (img.naturalWidth) {
-					img.title += ` (${img.naturalWidth} x ${img.naturalHeight})`;
+	load();
+	
+	return ctrl = {
+		el: button,
+		imgEl: img,
+		toggleEnable(enable) {
+			button.disabled = !enable;
+		},
+		toggleCheck() {
+			button.classList.toggle("checked");
+		},
+		selected() {
+			return !button.disabled && button.classList.contains("checked");
+		}
+	};
+	
+	function load() {
+		Promise.all([loadImage(), loadFileSize(), pref.ready()])
+			.then(() => {
+				if (pref.get("displayImageSizeUnderThumbnail")) {
+					const info = document.createElement("span");
+					info.className = "image-checkbox-info";
+					info.textContent = `${img.naturalWidth} x ${img.naturalHeight}`;
+					img.parentNode.insertBefore(info, img.nextSibling);
+				} else {
+					if (img.naturalWidth) {
+						img.title += ` (${img.naturalWidth} x ${img.naturalHeight})`;
+					}
 				}
-			}
-			img.title += ` [${formatFileSize(img.fileSize)}]`;
-			
-			// default width for svg
-			if (!img.naturalHeight) {
-				img.style.width = "200px";
-			}
-		})
-		.catch(err => {
-			console.error(err);
-			img.error = true;
-		})
-		.then(() => {
-			img.dispatchEvent(new CustomEvent("imageLoad", {
-				bubbles: true,
-				detail: {image: ctrl}
-			}));
-		});
+				img.title += ` [${formatFileSize(img.fileSize)}]`;
+				
+				// default width for svg
+				if (!img.naturalHeight) {
+					img.style.width = "200px";
+				}
+			})
+			.catch(err => {
+				console.error(err);
+				img.error = true;
+			})
+			.then(() => {
+				// https://bugzilla.mozilla.org/show_bug.cgi?id=329509
+				button.parentNode.dispatchEvent(new CustomEvent("imageLoad", {
+					bubbles: true,
+					detail: {image: ctrl}
+				}));
+			});
+	}
 		
 	function loadImage() {
 		return new Promise((resolve, reject) => {
@@ -214,32 +238,6 @@ function createImageCheckbox(url) {
 	function loadFileSize() {
 		return fetchBlob(url).then(b => img.fileSize = b.size);
 	}
-		
-	input.type = "checkbox";
-	input.checked = true;
-	input.onchange = () => {
-		label.classList.toggle("checked", input.checked);
-	};
-	label.appendChild(img);
-	label.appendChild(input);
-	label.className = "image-checkbox checked";
-	
-	return ctrl = {
-		el: label,
-		imgEl: img,
-		toggleEnable(_enable) {
-			enable = _enable;
-			label.classList.toggle("disable", !enable);
-			input.disabled = !enable;
-		},
-		toggleCheck() {
-			label.classList.toggle("checked");
-			input.checked = !input.checked;
-		},
-		selected() {
-			return enable && input.checked;
-		}
-	};
 }
 
 function formatFileSize(size) {


### PR DESCRIPTION
* It is easier to click on the button.

  - The image won't be dragged.
  - Never select text/images.
  - Always relies on click event that accurately reflects your mouse.
  
* Hard to distinguish between selected/unselected images?

  ![image](https://user-images.githubusercontent.com/1324510/41505211-3b4600f0-7236-11e8-9dca-581bdb770532.png)
