### PR TITLE
Fix: don't use saveAs option in batchDownload

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -404,7 +404,6 @@ function batchDownload({tabs, env}) {
 				url,
 				blob: blob || pref.get("useCache"),
 				filename: renderFilename(env),
-				saveAs: pref.get("saveAs"),
 				conflictAction: pref.get("filenameConflictAction")
 			}));
 			i++;


### PR DESCRIPTION
Fixes #139.