### PR TITLE
Add: support JS template transformation in URL maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ If the site displays a thumbnail image, you can transform the URL to its full si
 imgsa\.baidu\.com/.+/(\w+\.\w+)$
 imgsrc.baidu.com/forum/pic/item/$1
 
+# discord
+[^/]+\.discordapp\.net/external/[^/]+/(https?)/(.+?)\?.+$
+{$1}://{decodeURIComponent($2)}
+
 # twitter
 pbs\.twimg\.com/media/(.+\.\w+)$
 pbs.twimg.com/media/$1:orig
@@ -105,6 +109,7 @@ pbs.twimg.com/media/$1:orig
 * Each replace rule includes:
 	- A line of regex.
 	- A line of replacement.
+* If the replacement contains curly braces (`{}`), it would be treated as a JavaScript template string.
 * Lines starting with `#` are ignored.
 * Empty lines are ignored.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ imgsa\.baidu\.com/.+/(\w+\.\w+)$
 imgsrc.baidu.com/forum/pic/item/$1
 
 # discord
-[^/]+\.discordapp\.net/external/[^/]+/(https?)/(.+?)\?.+$
+[^/]+\.discordapp\.net/external/[^/]+/(https?)/(.+?)\?
 ${$1}://${decodeURIComponent($2)}
 
 # twitter

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ imgsrc.baidu.com/forum/pic/item/$1
 
 # discord
 [^/]+\.discordapp\.net/external/[^/]+/(https?)/(.+?)\?.+$
-{$1}://{decodeURIComponent($2)}
+${$1}://${decodeURIComponent($2)}
 
 # twitter
 pbs\.twimg\.com/media/(.+\.\w+)$
@@ -109,7 +109,7 @@ pbs.twimg.com/media/$1:orig
 * Each replace rule includes:
 	- A line of regex.
 	- A line of replacement.
-* If the replacement contains curly braces (`{}`), it would be treated as a JavaScript template string.
+* If the replacement contains template string variables (`${...}`), it would be treated as a JavaScript template string.
 * Lines starting with `#` are ignored.
 * Empty lines are ignored.
 

--- a/extension/content/url-map.js
+++ b/extension/content/url-map.js
@@ -25,8 +25,7 @@ const urlMap = function () {
   function createTransform(search, repl) {
     if (/\$\{[^}]+\}/.test(repl)) {
       const re = new RegExp(search, "i");
-      const fn = Function("$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8",
-        "$9", `return \`${repl}\``);
+      const fn = Function(...fnArgs(), `return \`${repl}\``);
       return url => {
         const match = url.match(re);
         if (!match) {
@@ -42,6 +41,12 @@ const urlMap = function () {
 	function transform(url) {
     return transforms.reduce((url, t) => t(url), url);
 	}
+  
+  function* fnArgs() {
+    for (let i = 0; i < 10; i++) {
+      yield `$${i}=""`;
+    }
+  }
 	
 	return {transform};
 }();

--- a/extension/content/url-map.js
+++ b/extension/content/url-map.js
@@ -40,7 +40,7 @@ const urlMap = function () {
   }
 	
 	function transform(url) {
-    return transforms.reduce((t, url) => t(url), url);
+    return transforms.reduce((url, t) => t(url), url);
 	}
 	
 	return {transform};

--- a/extension/content/url-map.js
+++ b/extension/content/url-map.js
@@ -23,7 +23,7 @@ const urlMap = function () {
 	}
   
   function createTransform(search, repl) {
-    if (/\{[^}]+\}/.test(repl)) {
+    if (/\$\{[^}]+\}/.test(repl)) {
       const re = new RegExp(search, "i");
       const fn = Function("$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8",
         "$9", `return \`${repl}\``);


### PR DESCRIPTION
This uses unsafe `Function`. Not sure if this violates the AMO policy.