### PR TITLE
Fix: capture drop event

### DIFF
--- a/extension/content/dragndrop.js
+++ b/extension/content/dragndrop.js
@@ -140,7 +140,7 @@ function initDownloadSingleImage({downloadImage}) {
       
       const events = [
         ["dragover", dragOver, pref.get("dragndropHard")],
-        ["drop", drop],
+        ["drop", drop, pref.get("dragndropHard")],
         ["dragend", dragEnd]
       ];
       for (const args of events) {


### PR DESCRIPTION
It doesn't work on twitter without capturing.