### PR TITLE
change min-width to auto

### DIFF
--- a/src/static/css/options.css
+++ b/src/static/css/options.css
@@ -11,7 +11,7 @@ body.version-lt-57 {
 }
 body[data-browser=Chrome] {
   padding: 0 1em 1em 1em;
-  min-width: 520px;
+  min-width: auto;
 }
 
 a {


### PR DESCRIPTION
It seems that Edge 99 rejects such a wide options interface. There is no way to distinguish between Edge and Chrome.